### PR TITLE
Added more port options in the cniconfig

### DIFF
--- a/pkg/fixtures/context.go
+++ b/pkg/fixtures/context.go
@@ -38,7 +38,7 @@ type TestingConfig struct {
 	NetworkName          string
 	PortName             string
 	ProjectName          string
-	SecurityGroups       []string
+	SecurityGroups       *[]string
 	SubnetName           string
 }
 
@@ -51,8 +51,11 @@ func WithTestConfig(t *testing.T, callback func(cfg TestingConfig)) {
 		NetworkName:          Getenv("OS_NETWORK_NAME", ""),
 		PortName:             Getenv("OS_PORT_NAME", "openstack-cni-test"),
 		ProjectName:          Getenv("OS_PROJECT_NAME", ""),
-		SecurityGroups:       strings.Split(Getenv("OS_SECURITY_GROUPS", ""), ";"),
 		SubnetName:           Getenv("OS_SUBNET_NAME", ""),
+	}
+	sgs := strings.Split(Getenv("OS_SECURITY_GROUPS", ""), ";")
+	if len(sgs) > 0 {
+		cfg.SecurityGroups = &sgs
 	}
 
 	if cfg.EnableOpenstackTests == "1" {

--- a/pkg/openstack/client.go
+++ b/pkg/openstack/client.go
@@ -88,7 +88,6 @@ func (me *openstackClient) DetachPort(portId, serverId string) error {
 	return result.ExtractErr()
 }
 
-
 var ErrServerNotFound = fmt.Errorf("server not found")
 
 // GetServer returns a single server based on a server name

--- a/pkg/openstack/port_manager_test.go
+++ b/pkg/openstack/port_manager_test.go
@@ -26,8 +26,22 @@ func Test_PortManager(t *testing.T) {
 			SetupAndTeardownPort(t, context, client)
 		})
 
-		t.Run("can setup a port with a subnet and tear it down", func(t *testing.T) {
+		t.Run("can setup a port with all options and tear it down", func(t *testing.T) {
 			context.CniConfig.SubnetName = cfg.SubnetName
+			context.CniConfig.PortDescription = "description"
+			f := false
+			context.CniConfig.AdminStateUp = &f
+			context.CniConfig.MacAddress = "52:54:00:28:ea:16"
+			// This cannot be tested without a sepcific device id
+			// context.CniConfig.DeviceId = "4be2ed0a-23c4-4c5b-91b3-eedce17b3de2"
+			context.CniConfig.DeviceOwner = "compute:nova"
+			context.CniConfig.TenantId = "67f06cc9d851455f94fc0380233ab86c"
+			context.CniConfig.AllowedAddressPairs = []util.AddressPair{{IpAddress: "1.1.1.1", MacAddress: "52:54:00:28:ea:16"}}
+			// This cannot be tested unless openstack is setup to accept specific value spec pairs
+			// context.CniConfig.ValueSpecs = &map[string]string{
+			// 	"foo": "bar",
+			// }
+
 			SetupAndTeardownPort(t, context, client)
 		})
 	})

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -112,7 +112,7 @@ func NewCniConfig(bytes []byte) (CniConfig, error) {
 	if err := json.Unmarshal(bytes, conf); err != nil {
 		return *conf, fmt.Errorf("Failed to load config data, error = %+v", err)
 	}
-	if conf.PortName != "" {
+	if conf.PortName == "" {
 		conf.PortName = Getenv("OS_PORT_NAME", "openstack-cni")
 	}
 	if conf.ProjectName == "" {

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -91,11 +91,20 @@ func (me CniCommand) ForLog() [][]string {
 */
 type CniConfig struct {
 	*types.NetConf
-	Network        string   `json:"network,omitempty"`
-	PortName       string   `json:"port_name,omitempty"`
-	ProjectName    string   `json:"project_name,omitempty"`
-	SecurityGroups []string `json:"security_groups,omitempty"`
-	SubnetName     string   `json:"subnet_name,omitempty"`
+	AllowedAddressPairs []AddressPair `json:"allowed_address_pairs,omitempty"`
+	AdminStateUp        *bool         `json:"admin_state_up,omitempty"`
+	DeviceId            string        `json:"device_id,omitempty"`
+	DeviceOwner         string        `json:"device_owner,omitempty"`
+	// FixedIPs string `json:"fixed_ips,omitempty"`
+	MacAddress      string             `json:"mac_address,omitempty"`
+	Network         string             `json:"network,omitempty"`
+	PortDescription string             `json:"port_description,omitempty"`
+	PortName        string             `json:"port_name,omitempty"`
+	ProjectName     string             `json:"project_name,omitempty"`
+	SecurityGroups  *[]string          `json:"security_groups,omitempty"`
+	SubnetName      string             `json:"subnet_name,omitempty"`
+	TenantId        string             `json:"tenant_id,omitempty"`
+	ValueSpecs      *map[string]string `json:"value_specs,omitempty"`
 }
 
 func NewCniConfig(bytes []byte) (CniConfig, error) {
@@ -103,7 +112,7 @@ func NewCniConfig(bytes []byte) (CniConfig, error) {
 	if err := json.Unmarshal(bytes, conf); err != nil {
 		return *conf, fmt.Errorf("Failed to load config data, error = %+v", err)
 	}
-	if conf.PortName == "" {
+	if conf.PortName != "" {
 		conf.PortName = Getenv("OS_PORT_NAME", "openstack-cni")
 	}
 	if conf.ProjectName == "" {
@@ -111,6 +120,11 @@ func NewCniConfig(bytes []byte) (CniConfig, error) {
 	}
 
 	return *conf, nil
+}
+
+type AddressPair struct {
+	IpAddress  string `json:"ip_address,omitempty"`
+	MacAddress string `json:"mac_address,omitempty"`
 }
 
 // ParseCniArgs parses a key value pair such as "IgnoreUnknown=true;K8S_POD_NAMESPACE=lightning;"

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,11 +36,3 @@ func DirExists(dir string) bool {
 	}
 	return info.IsDir()
 }
-
-func IsNilOrZero[T any](v *T) bool {
-	return v == nil || v == new(T)
-}
-
-func HasValue[T any](v *T) bool {
-	return v != nil && v != new(T)
-}

--- a/pkg/util/util.go
+++ b/pkg/util/util.go
@@ -36,3 +36,11 @@ func DirExists(dir string) bool {
 	}
 	return info.IsDir()
 }
+
+func IsNilOrZero[T any](v *T) bool {
+	return v == nil || v == new(T)
+}
+
+func HasValue[T any](v *T) bool {
+	return v != nil && v != new(T)
+}


### PR DESCRIPTION
The following options are now available in the cniconfig:

- admin_state_up (defaults to `true`)
- allowed_address_pairs
- description
- device_id
- device_owner
- mac_address 
- tenant_id
- value_specs