### PR TITLE
Release 0.0.28

### DIFF
--- a/pkg/cniplugin/cni_test.go
+++ b/pkg/cniplugin/cni_test.go
@@ -1,9 +1,11 @@
 package cniplugin_test
 
 import (
+	"fmt"
 	"net"
 	"os"
 	"testing"
+	"time"
 
 	currentcni "github.com/containernetworking/cni/pkg/types/040"
 	"github.com/go-chi/httplog"
@@ -19,6 +21,27 @@ import (
 func Test_Cni(t *testing.T) {
 	testData := fixtures.NewTestData()
 
+	getLocalMac := func(t *testing.T) string {
+		t.Helper()
+		ifaces, err := net.Interfaces()
+		Assert(t).That(err, IsNil())
+		for _, iface := range ifaces {
+			// return the first interface with a MAC
+			if iface.HardwareAddr == nil {
+				continue
+			}
+			return iface.HardwareAddr.String()
+		}
+		// if none of the interfaces had a MAC default to the first interface
+		return ifaces[0].HardwareAddr.String()
+	}
+	getLocalMacAddr := func(t *testing.T) net.HardwareAddr {
+		t.Helper()
+		mac, err := net.ParseMAC(getLocalMac(t))
+		Assert(t).That(err, IsNil())
+		return mac
+	}
+
 	t.Run("can execute an add", func(t *testing.T) {
 		cniHandler := &mocks.CommandHandlerMock{}
 		networking := &mocks.NetworkingMock{}
@@ -31,11 +54,13 @@ func Test_Cni(t *testing.T) {
 				result := testData.CniResult()
 
 				// setup the mac as the mac of an interface on our machine so the lookup doesn't fail
-				ifaces, err := net.Interfaces()
-				Assert(t).That(err, IsNil())
-				result.Interfaces[0].Mac = ifaces[0].HardwareAddr.String()
+				result.Interfaces[0].Mac = getLocalMac(t)
 
 				return result, nil
+			}
+
+			networking.GetIfaceByMacFunc = func(mac string) (*net.Interface, error) {
+				return &net.Interface{}, nil
 			}
 
 			// skip doing any of the netlink configuration
@@ -46,6 +71,51 @@ func Test_Cni(t *testing.T) {
 			args := testData.SkelArgs()
 
 			cni := cniplugin.NewCni(cniclient, networking, cniplugin.DefaultCniOpts())
+			err := cni.Add(args)
+			Assert(t).That(err, IsNil())
+
+			Assert(t).That(cniHandler.AddCalls(), HasLen(1))
+			Assert(t).That(networking.ConfigureCalls(), HasLen(1))
+		})
+	})
+
+	t.Run("retrying GetIfaceByMacFunc works", func(t *testing.T) {
+		cniHandler := &mocks.CommandHandlerMock{}
+		networking := &mocks.NetworkingMock{}
+		sopts := &ServerOpts{CniHandler: cniHandler, Networking: networking}
+
+		WithServerOpts(t, sopts, func(fix *ServerFixture) {
+			cniclient := fix.CniClient()
+			// provide a meaningful result back from the http server
+			result := testData.CniResult()
+			// setup the mac as the mac of an interface on our machine so the lookup doesn't fail
+			result.Interfaces[0].Mac = getLocalMac(t)
+			cniHandler.AddFunc = func(cmd util.CniCommand) (*currentcni.Result, error) {
+				return result, nil
+			}
+
+			// simiulate failure to look up the mac address for some amount of time
+			count := 0
+			networking.GetIfaceByMacFunc = func(mac string) (*net.Interface, error) {
+				if count < 3 {
+					time.Sleep(time.Duration(time.Millisecond * 50))
+					count += 1
+					return nil, fmt.Errorf("interface not found")
+				}
+				return &net.Interface{
+					HardwareAddr: getLocalMacAddr(t),
+				}, nil
+			}
+
+			// skip doing any of the netlink configuration
+			networking.ConfigureFunc = func(namespace string, iface *cniplugin.NetworkInterface) error {
+				return nil
+			}
+
+			args := testData.SkelArgs()
+
+			cniOpts := cniplugin.DefaultCniOpts()
+			cni := cniplugin.NewCni(cniclient, networking, cniOpts)
 			err := cni.Add(args)
 			Assert(t).That(err, IsNil())
 

--- a/pkg/openstack/port_manager.go
+++ b/pkg/openstack/port_manager.go
@@ -102,10 +102,7 @@ func (me *PortManager) SetupPort(opts SetupPortOpts) (*SetupPortResult, error) {
 
 	log.Info().Msg("creating port")
 	// account for non-default port create options
-	extraCreateOpts := ExtraCreatePortOpts{EnablePortSecurity: nil}
-	if opts.EnablePortSecurity != nil {
-		extraCreateOpts.EnablePortSecurity = opts.EnablePortSecurity
-	}
+	extraCreateOpts := opts.CreateExtraPortOpts()
 	result.Port, err = me.client.CreatePort(portOpts, &extraCreateOpts)
 	if err != nil {
 		return result, err
@@ -235,7 +232,20 @@ type SetupPortOpts struct {
 	Tags                NeutronTags
 	TenantId            string
 	ValueSpecs          *map[string]string
-	EnablePortSecurity  *bool
+	// extra options
+	PortSecurityEnabled *bool
+	HostID              string
+	VNICType            string
+	Profile             map[string]interface{}
+}
+
+func (me *SetupPortOpts) CreateExtraPortOpts() ExtraCreatePortOpts {
+	return ExtraCreatePortOpts{
+		PortSecurityEnabled: me.PortSecurityEnabled,
+		HostID:              me.HostID,
+		VNICType:            me.VNICType,
+		Profile:             me.Profile,
+	}
 }
 
 func SetupPortOptsFromContext(context util.CniContext) SetupPortOpts {
@@ -254,7 +264,10 @@ func SetupPortOptsFromContext(context util.CniContext) SetupPortOpts {
 		SubnetName:          context.CniConfig.SubnetName,
 		TenantId:            context.CniConfig.TenantId,
 		ValueSpecs:          context.CniConfig.ValueSpecs,
-		EnablePortSecurity:  context.CniConfig.EnablePortSecurity,
+		PortSecurityEnabled: context.CniConfig.PortSecurityEnabled,
+		HostID: context.CniConfig.HostID,
+		VNICType: context.CniConfig.VNICType,
+		Profile: context.CniConfig.Profile,
 	}
 }
 

--- a/pkg/openstack/port_manager_test.go
+++ b/pkg/openstack/port_manager_test.go
@@ -49,14 +49,14 @@ func Test_PortManager(t *testing.T) {
 		t.Run("can setup a port with port security enabled", func(t *testing.T) {
 			context := CniContextFromConfig(t, cfg, cmd)
 			enabled := true
-			context.CniConfig.EnablePortSecurity = &enabled
+			context.CniConfig.PortSecurityEnabled = &enabled
 			SetupAndTeardownPort(t, context, client)
 		})
 
 		t.Run("can setup a port with port security disabled", func(t *testing.T) {
 			context := CniContextFromConfig(t, cfg, cmd)
 			enabled := false
-			context.CniConfig.EnablePortSecurity = &enabled
+			context.CniConfig.PortSecurityEnabled = &enabled
 			// Port security cannot be disabled if security groups are provided
 			context.CniConfig.SecurityGroups = nil
 			SetupAndTeardownPort(t, context, client)

--- a/pkg/util/config.go
+++ b/pkg/util/config.go
@@ -97,16 +97,26 @@ type CniConfig struct {
 	DeviceId            string        `json:"device_id,omitempty"`
 	DeviceOwner         string        `json:"device_owner,omitempty"`
 	// FixedIPs string `json:"fixed_ips,omitempty"`
-	MacAddress         string             `json:"mac_address,omitempty"`
-	Network            string             `json:"network,omitempty"`
-	PortDescription    string             `json:"port_description,omitempty"`
-	PortName           string             `json:"port_name,omitempty"`
-	ProjectName        string             `json:"project_name,omitempty"`
-	SecurityGroups     *[]string          `json:"security_groups,omitempty"`
-	SubnetName         string             `json:"subnet_name,omitempty"`
-	TenantId           string             `json:"tenant_id,omitempty"`
-	ValueSpecs         *map[string]string `json:"value_specs,omitempty"`
-	EnablePortSecurity *bool              `json:"enable_port_security,omitempty"`
+	MacAddress      string             `json:"mac_address,omitempty"`
+	Network         string             `json:"network,omitempty"`
+	PortDescription string             `json:"port_description,omitempty"`
+	PortName        string             `json:"port_name,omitempty"`
+	ProjectName     string             `json:"project_name,omitempty"`
+	SecurityGroups  *[]string          `json:"security_groups,omitempty"`
+	SubnetName      string             `json:"subnet_name,omitempty"`
+	TenantId        string             `json:"tenant_id,omitempty"`
+	ValueSpecs      *map[string]string `json:"value_specs,omitempty"`
+	// PortSecurityEnabled toggles port security on a port.
+	PortSecurityEnabled *bool `json:"port_security_enabled,omitempty"`
+	// The ID of the host where the port is allocated.
+	HostID string `json:"binding:host_id,omitempty"`
+	// The virtual network interface card (vNIC) type that is bound to the
+	// neutron port.
+	VNICType string `json:"binding:vnic_type,omitempty"`
+	// A dictionary that enables the application running on the specified
+	// host to pass and receive virtual network interface (VIF) port-specific
+	// information to the plug-in.
+	Profile map[string]interface{} `json:"binding:profile,omitempty"`
 }
 
 func NewCniConfig(bytes []byte) (CniConfig, error) {
@@ -125,8 +135,8 @@ func NewCniConfig(bytes []byte) (CniConfig, error) {
 	}
 	// port security is enabled by default
 	t := true
-	if conf.EnablePortSecurity == nil {
-		conf.EnablePortSecurity = &t
+	if conf.PortSecurityEnabled == nil {
+		conf.PortSecurityEnabled = &t
 	}
 
 	return *conf, nil


### PR DESCRIPTION
* Added `portbinding` options.  `binding:host_id, binding:vnic_type and binding:profile`
* Added retry behavior when failing to lookup an interface by MAC Address